### PR TITLE
[GRM-287] - Tasks scheduled by the scheduler seem to either behave erratically or don't run at all.

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -352,6 +352,7 @@ func (c *Cron) run() {
 				c.removeEntry(id)
 				c.logger.Info("removed", "entry", id)
 			case <-c.recalculateTimer:
+				now = c.now()
 				break
 			}
 


### PR DESCRIPTION
[GRM-287]

The reason this is necessary is because once the first clock synchronisation callback is fired, the timer will become locked to a single point in time. The `break` statement will cause the inner `for` loop to complete, as shown below, but will not cause any update to the cached `now` value (without the addition of the new `now` line).
https://github.com/team-rocos/cron/blob/966ed6863c9e1311d6e9e9244a21b06e257850ba/cron.go#L354-L359

This means that each time we recalculate the time because of a time synchronisation, the `now` value will always be the same and since the job time is not changing, the two times will always return the same positive difference, never getting any closer to each other. As can be seen on the code block below- in particular line 312. This obviously doesn't mean the timer will never fire, it just means that the remaining time to start a task must be less than the duration until the next time synchronisation.
https://github.com/team-rocos/cron/blob/966ed6863c9e1311d6e9e9244a21b06e257850ba/cron.go#L302-L315

[GRM-287]: https://dronedeploy.atlassian.net/browse/GRM-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ